### PR TITLE
Fix multiple connections problems to one same nqn in a single node

### DIFF
--- a/deploy/kubernetes/csi-nvmf-node.yaml
+++ b/deploy/kubernetes/csi-nvmf-node.yaml
@@ -73,6 +73,8 @@ spec:
             - name: pods-mount-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
+            - name: run-nvmf-dir
+              mountPath: /run/nvmf
             - name: host-dev
               mountPath: /dev
               mountPropagation: "HostToContainer"
@@ -94,6 +96,10 @@ spec:
           hostPath:
             path: /var/lib/kubelet/pods
             type: Directory
+        - name: run-nvmf-dir
+          hostPath:
+            path: /run/nvmf
+            type: DirectoryOrCreate
         - name: host-dev
           hostPath:
             path: /dev

--- a/pkg/nvmf/const.go
+++ b/pkg/nvmf/const.go
@@ -18,6 +18,7 @@ package nvmf
 const (
 	NVMF_NQN_SIZE = 223
 	SYS_NVMF      = "/sys/class/nvme"
+	RUN_NVMF      = "/run/nvmf"
 )
 
 // Here erron

--- a/pkg/nvmf/errors.go
+++ b/pkg/nvmf/errors.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvmf
+
+import "fmt"
+
+type NoControllerError struct {
+	Nqn     string
+	Hostnqn string
+}
+
+func (e *NoControllerError) Error() string {
+	return fmt.Sprintf("not found controller: nqn=%s, hostnqn=%s", e.Nqn, e.Hostnqn)
+}
+
+type UnsupportedHostnqnError struct {
+	Target string
+}
+
+func (e *UnsupportedHostnqnError) Error() string {
+	return fmt.Sprintf("unsupported hostnqn sysfs file: target=%s", e.Target)
+}

--- a/pkg/nvmf/fabrics.go
+++ b/pkg/nvmf/fabrics.go
@@ -216,6 +216,8 @@ func disconnectByNqn(nqn, hostnqn string) int {
 						}
 					}
 				}
+
+				return ret
 			}
 		} else {
 			ret++

--- a/pkg/nvmf/fabrics.go
+++ b/pkg/nvmf/fabrics.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/kubernetes-csi/csi-driver-nvmf/pkg/utils"
@@ -176,7 +177,7 @@ func disconnectByNqn(nqn, hostnqn string) int {
 	}
 
 	// delete hostnqn file
-	hostnqnPath := strings.Join([]string{RUN_NVMF, nqn, b64.StdEncoding.EncodeToString([]byte(hostnqn))}, "/")
+	hostnqnPath := filepath.Join(RUN_NVMF, nqn, b64.StdEncoding.EncodeToString([]byte(hostnqn)))
 	os.Remove(hostnqnPath)
 
 	devices, err := ioutil.ReadDir(SYS_NVMF)
@@ -191,7 +192,7 @@ func disconnectByNqn(nqn, hostnqn string) int {
 		}
 	}
 
-	nqnPath := strings.Join([]string{RUN_NVMF, nqn}, "/")
+	nqnPath := filepath.Join(RUN_NVMF, nqn)
 	hostnqns, err := ioutil.ReadDir(nqnPath)
 	if err != nil {
 		klog.Errorf("Disconnect: readdir %s err: %v", nqnPath, err)
@@ -258,7 +259,7 @@ func (c *Connector) Connect() (string, error) {
 	}
 
 	// create nqn directory
-	nqnPath := strings.Join([]string{RUN_NVMF, c.TargetNqn}, "/")
+	nqnPath := filepath.Join(RUN_NVMF, c.TargetNqn)
 	if err := os.MkdirAll(nqnPath, 0750); err != nil {
 		klog.Errorf("create nqn directory %s error %v, rollback!!!", c.TargetNqn, err)
 		ret := disconnectByNqn(c.TargetNqn, c.HostNqn)
@@ -269,7 +270,7 @@ func (c *Connector) Connect() (string, error) {
 	}
 
 	// create hostnqn file
-	hostnqnPath := strings.Join([]string{RUN_NVMF, c.TargetNqn, b64.StdEncoding.EncodeToString([]byte(c.HostNqn))}, "/")
+	hostnqnPath := filepath.Join(RUN_NVMF, c.TargetNqn, b64.StdEncoding.EncodeToString([]byte(c.HostNqn)))
 	file, err := os.Create(hostnqnPath)
 	if err != nil {
 		klog.Errorf("create hostnqn file %s:%s error %v, rollback!!!", c.TargetNqn, c.HostNqn, err)

--- a/pkg/nvmf/fabrics.go
+++ b/pkg/nvmf/fabrics.go
@@ -88,11 +88,11 @@ func _disconnect(sysfs_path string) error {
 }
 
 func disconnectSubsysWithHostNqn(nqn, hostnqn, ctrl string) (res bool) {
-	sysfs_nqn_path := fmt.Sprintf("%s/%s/subsysnqn", SYS_NVMF, ctrl)
+	sysfs_subsysnqn_path := fmt.Sprintf("%s/%s/subsysnqn", SYS_NVMF, ctrl)
 	sysfs_hostnqn_path := fmt.Sprintf("%s/%s/hostnqn", SYS_NVMF, ctrl)
 	sysfs_del_path := fmt.Sprintf("%s/%s/delete_controller", SYS_NVMF, ctrl)
 
-	file, err := os.Open(sysfs_nqn_path)
+	file, err := os.Open(sysfs_subsysnqn_path)
 	if err != nil {
 		klog.Errorf("Disconnect: open file %s err: %v", file.Name(), err)
 		return false
@@ -138,10 +138,10 @@ func disconnectSubsysWithHostNqn(nqn, hostnqn, ctrl string) (res bool) {
 }
 
 func disconnectSubsys(nqn, ctrl string) (res bool) {
-	sysfs_nqn_path := fmt.Sprintf("%s/%s/subsysnqn", SYS_NVMF, ctrl)
+	sysfs_subsysnqn_path := fmt.Sprintf("%s/%s/subsysnqn", SYS_NVMF, ctrl)
 	sysfs_del_path := fmt.Sprintf("%s/%s/delete_controller", SYS_NVMF, ctrl)
 
-	file, err := os.Open(sysfs_nqn_path)
+	file, err := os.Open(sysfs_subsysnqn_path)
 	if err != nil {
 		klog.Errorf("Disconnect: open file %s err: %v", file.Name(), err)
 		return false

--- a/pkg/nvmf/nodeserver.go
+++ b/pkg/nvmf/nodeserver.go
@@ -32,11 +32,6 @@ type NodeServer struct {
 }
 
 func NewNodeServer(d *driver) *NodeServer {
-	if err := os.MkdirAll(RUN_NVMF, 0750); err != nil {
-		klog.Errorf("NewNodeServer: failed to mkdir %s, error: %v", RUN_NVMF, err)
-		return nil
-	}
-
 	return &NodeServer{
 		Driver: d,
 	}

--- a/pkg/nvmf/nodeserver.go
+++ b/pkg/nvmf/nodeserver.go
@@ -32,6 +32,11 @@ type NodeServer struct {
 }
 
 func NewNodeServer(d *driver) *NodeServer {
+	if err := os.MkdirAll(RUN_NVMF, 0750); err != nil {
+		klog.Errorf("NewNodeServer: failed to mkdir %s, error: %v", RUN_NVMF, err)
+		return nil
+	}
+
 	return &NodeServer{
 		Driver: d,
 	}
@@ -53,7 +58,6 @@ func (n *NodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCa
 }
 
 func (n *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
-
 	// 1. check parameters
 	if req.GetVolumeCapability() == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "NodePublishVolume missing Volume Capability in req.")

--- a/pkg/nvmf/nvmf.go
+++ b/pkg/nvmf/nvmf.go
@@ -142,11 +142,6 @@ func AttachDisk(req *csi.NodePublishVolumeRequest, nm nvmfDiskMounter) (string, 
 
 	// Tips: use k8s mounter to mount fs and only support "ext4"
 	var options []string
-	if nm.readOnly {
-		options = append(options, "ro")
-	} else {
-		options = append(options, "rw")
-	}
 	options = append(options, nm.mountOptions...)
 	err = nm.mounter.FormatAndMount(devicePath, mntPath, nm.fsType, options)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This makes multiple connections to one same nqn possible in a single node and makes readonly and readwrite mounts simultaneously for one block device.

**Which issue(s) this PR fixes**:
Fixes #22

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

```release-note
none
```