### PR TITLE
Allow overriding hostNqn/hostId

### DIFF
--- a/pkg/nvmf/fabrics.go
+++ b/pkg/nvmf/fabrics.go
@@ -42,16 +42,26 @@ type Connector struct {
 }
 
 func getNvmfConnector(nvmfInfo *nvmfDiskInfo) *Connector {
-	hostnqnData, err := os.ReadFile("/etc/nvme/hostnqn")
-	hostnqn := strings.TrimSpace(string(hostnqnData))
-	if err != nil {
-		hostnqn = ""
+	hostnqn := ""
+	if nvmfInfo.HostNqn != "" {
+		hostnqn = nvmfInfo.HostNqn
+	} else {
+		hostnqnData, err := os.ReadFile("/etc/nvme/hostnqn")
+		hostnqn = strings.TrimSpace(string(hostnqnData))
+		if err != nil {
+			hostnqn = ""
+		}
 	}
 
-	hostidData, err := os.ReadFile("/etc/nvme/hostid")
-	hostid := strings.TrimSpace(string(hostidData))
-	if err != nil {
-		hostid = ""
+	hostid := ""
+	if nvmfInfo.HostId != "" {
+		hostid = nvmfInfo.HostId
+	} else {
+		hostidData, err := os.ReadFile("/etc/nvme/hostid")
+		hostid = strings.TrimSpace(string(hostidData))
+		if err != nil {
+			hostid = ""
+		}
 	}
 
 	return &Connector{

--- a/pkg/nvmf/nvmf.go
+++ b/pkg/nvmf/nvmf.go
@@ -33,6 +33,8 @@ type nvmfDiskInfo struct {
 	Port       string
 	DeviceUUID string
 	Transport  string
+	HostId     string
+	HostNqn    string
 }
 
 type nvmfDiskMounter struct {
@@ -59,6 +61,8 @@ func getNVMfDiskInfo(req *csi.NodePublishVolumeRequest) (*nvmfDiskInfo, error) {
 	targetTrPort := volOpts["targetTrPort"]
 	targetTrType := volOpts["targetTrType"]
 	deviceUUID := volOpts["deviceUUID"]
+	devHostNqn := volOpts["hostNqn"]
+	devHostId := volOpts["hostId"]
 	nqn := volOpts["nqn"]
 
 	if targetTrAddr == "" || nqn == "" || targetTrPort == "" || targetTrType == "" || deviceUUID == "" {
@@ -72,6 +76,8 @@ func getNVMfDiskInfo(req *csi.NodePublishVolumeRequest) (*nvmfDiskInfo, error) {
 		Nqn:        nqn,
 		DeviceUUID: deviceUUID,
 		Transport:  targetTrType,
+		HostNqn:    devHostNqn,
+		HostId:     devHostId,
 	}, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
When using NQNs on storage to differentiate hosts, in some cases, you might want to differentiate workloads (e.g. kubevirt machines as separate hosts)
As you cannot have one hostId and multiple hostNqns (it will end up with similar errors like #34), we need to be able to override both (potentially we might set some default derived/hashed value for hostId, if desired)

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
Rebased on top of #36, the diff should be way smaller when #36 is merged

**Does this PR introduce a user-facing change?**:
```release-note
Add handling for optional HostNqn and HostId in volumeAttributes
```
